### PR TITLE
增加容器化的使用方式

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM chromedp/headless-shell
+
+WORKDIR /data
+
+COPY mdout /usr/local/bin
+
+RUN mdout install theme -u https://github.com/JabinGP/mdout-theme-github/archive/0.1.1.zip -n github -k
+
+ENTRYPOINT ["mdout"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+
+
+default: build_linux image clean
+
+clean:
+	rm -f mdout
+
+build_mac:
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build .
+
+build_linux:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build .
+
+image:
+	docker build -t mdout .

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -24,6 +24,7 @@ func getInstallCmd() *cobra.Command {
 
 func getInstallThemeCmd() *cobra.Command {
 	var url, name string
+	var skipTlsVerify bool
 	var cmd = &cobra.Command{
 		Use:   "theme",
 		Short: "下载主题",
@@ -32,11 +33,12 @@ func getInstallThemeCmd() *cobra.Command {
 			if url == "" || name == "" {
 				return fmt.Errorf("url = %s，name = %s，指定的 url 或者 name 为空！", url, name)
 			}
-			return theme.DownloadTheme(url, name)
+			return theme.DownloadTheme(url, name, skipTlsVerify)
 		},
 	}
 
 	cmd.Flags().StringVarP(&url, "url", "u", "", "主题文件zip包的地址")
 	cmd.Flags().StringVarP(&name, "name", "n", "", "主题文件保存的文件夹名")
+	cmd.Flags().BoolVarP(&skipTlsVerify, "skipTlsVerity", "k", false, "跳过https证书检查")
 	return cmd
 }

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,5 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/PuerkitoBio/goquery v1.5.1 h1:PSPBGne8NIUWw+/7vFBV+kG2J/5MOjbzc7154OaKCSE=
-github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
-github.com/andybalholm/cascadia v1.1.0 h1:BuuO6sSfQNFRu1LppgbD25Hr2vLYW25JvxHs5zzsLTo=
-github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/chromedp/cdproto v0.0.0-20200116234248-4da64dd111ac/go.mod h1:PfAWWKJqjlGFYJEidUM6aVIWPr0EpobeyVWEEmplX7g=
 github.com/chromedp/cdproto v0.0.0-20200209033844-7e00b02ea7d2 h1:osPk40NN+GLEj2Tay/N+H/K4itKyHZ6gdrC/pXjjgQ8=
@@ -75,12 +71,7 @@ gitlab.com/golang-commonmark/puny v0.0.0-20191124015043-9f83538fa04f/go.mod h1:T
 gitlab.com/opennota/wd v0.0.0-20180912061657-c5d65f63c638 h1:uPZaMiz6Sz0PZs3IZJWpU5qHKGNy///1pacZC9txiUI=
 gitlab.com/opennota/wd v0.0.0-20180912061657-c5d65f63c638/go.mod h1:EGRJaqe2eO9XGmFtQCvV3Lm9NLico3UhFwUpCG/+mVU=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
-golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42 h1:vEOn+mP2zCOVzKckCZy6YsCtDblrpj/w7B9nxGNELpg=


### PR DESCRIPTION
通过构建docker镜像，使用户免于部署chrome环境，在linux服务器上尤其方便。
由于在build docker镜像时会下载默认的主题，但未能正确校验github的https证书，因此为install选项增加了一个-k参数以跳过https校验